### PR TITLE
Instead of skipping all riscv64 tests, only skip timeout-based tests

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -143,7 +143,6 @@ jobs:
           CIBW_BUILD: ${{ matrix.build }}
           CIBW_ENABLE: cpython-prerelease pypy
           CIBW_MANYLINUX_RISCV64_IMAGE: ${{ matrix.manylinux }}
-          CIBW_TEST_SKIP: ${{ matrix.cibw_arch == 'riscv64' && '*-linux_riscv64' || '' }}
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macosx_deployment_target }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -163,8 +163,11 @@ def assert_tuple_approx_equal(
             pytest.fail(msg + ": " + repr(actuals) + " != " + repr(targets))
 
 
-def timeout_unless_slower_valgrind(timeout: float) -> pytest.MarkDecorator:
-    if "PILLOW_VALGRIND_TEST" in os.environ:
+def timeout_unless_slower(timeout: float) -> pytest.MarkDecorator:
+    if (
+        "PILLOW_VALGRIND_TEST" in os.environ
+        or os.environ.get("AUDITWHEEL_ARCH") == "riscv64"
+    ):
         return pytest.mark.pil_noop_mark()
     return pytest.mark.timeout(timeout)
 

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -15,7 +15,7 @@ from .helper import (
     is_win32,
     mark_if_feature_version,
     skip_unless_feature,
-    timeout_unless_slower_valgrind,
+    timeout_unless_slower,
 )
 
 HAS_GHOSTSCRIPT = EpsImagePlugin.has_ghostscript()
@@ -405,7 +405,7 @@ def test_emptyline() -> None:
     assert image.format == "EPS"
 
 
-@timeout_unless_slower_valgrind(5)
+@timeout_unless_slower(5)
 @pytest.mark.parametrize(
     "test_file",
     ["Tests/images/eps/timeout-d675703545fee17acab56e5fec644c19979175de.eps"],

--- a/Tests/test_file_fli.py
+++ b/Tests/test_file_fli.py
@@ -11,7 +11,7 @@ from .helper import (
     assert_image_equal,
     assert_image_equal_tofile,
     is_pypy,
-    timeout_unless_slower_valgrind,
+    timeout_unless_slower,
 )
 
 # created as an export of a palette image from Gimp2.6
@@ -196,7 +196,7 @@ def test_seek() -> None:
         "Tests/images/timeout-bff0a9dc7243a8e6ede2408d2ffa6a9964698b87.fli",
     ],
 )
-@timeout_unless_slower_valgrind(3)
+@timeout_unless_slower(3)
 def test_timeouts(test_file: str) -> None:
     with open(test_file, "rb") as f:
         with Image.open(f) as im:

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -31,7 +31,7 @@ from .helper import (
     is_win32,
     mark_if_feature_version,
     skip_unless_feature,
-    timeout_unless_slower_valgrind,
+    timeout_unless_slower,
 )
 
 ElementTree: ModuleType | None
@@ -1048,7 +1048,7 @@ class TestFileJpeg:
         with pytest.raises(ValueError):
             im.save(f, xmp=b"1" * 65505)
 
-    @timeout_unless_slower_valgrind(1)
+    @timeout_unless_slower(1)
     def test_eof(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Even though this decoder never says that it is finished
         # the image should still end when there is no new data

--- a/Tests/test_file_pdf.py
+++ b/Tests/test_file_pdf.py
@@ -17,7 +17,7 @@ from .helper import (
     hopper,
     mark_if_feature_version,
     skip_unless_feature,
-    timeout_unless_slower_valgrind,
+    timeout_unless_slower,
 )
 
 
@@ -344,7 +344,7 @@ def test_pdf_append_to_bytesio() -> None:
     assert len(f.getvalue()) > initial_size
 
 
-@timeout_unless_slower_valgrind(1)
+@timeout_unless_slower(1)
 @pytest.mark.parametrize("newline", (b"\r", b"\n"))
 def test_redos(newline: bytes) -> None:
     malicious = b" trailer<<>>" + newline * 3456

--- a/Tests/test_file_tiff.py
+++ b/Tests/test_file_tiff.py
@@ -28,7 +28,7 @@ from .helper import (
     hopper,
     is_pypy,
     is_win32,
-    timeout_unless_slower_valgrind,
+    timeout_unless_slower,
 )
 
 ElementTree: ModuleType | None
@@ -1015,7 +1015,7 @@ class TestFileTiff:
             with pytest.raises(OSError):
                 im.load()
 
-    @timeout_unless_slower_valgrind(6)
+    @timeout_unless_slower(6)
     @pytest.mark.filterwarnings("ignore:Truncated File Read")
     def test_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
         with Image.open("Tests/images/timeout-6646305047838720") as im:
@@ -1028,7 +1028,7 @@ class TestFileTiff:
             "Tests/images/oom-225817ca0f8c663be7ab4b9e717b02c661e66834.tif",
         ],
     )
-    @timeout_unless_slower_valgrind(2)
+    @timeout_unless_slower(2)
     def test_oom(self, test_file: str) -> None:
         with pytest.raises(UnidentifiedImageError):
             with pytest.warns(UserWarning, match="Corrupt EXIF data"):

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -34,7 +34,7 @@ from .helper import (
     is_win32,
     mark_if_feature_version,
     skip_unless_feature,
-    timeout_unless_slower_valgrind,
+    timeout_unless_slower,
 )
 
 ElementTree: ModuleType | None
@@ -577,7 +577,7 @@ class TestImage:
         i = Image.new("RGB", [1, 1])
         assert isinstance(i.size, tuple)
 
-    @timeout_unless_slower_valgrind(0.75)
+    @timeout_unless_slower(0.75)
     @pytest.mark.parametrize("size", ((0, 100000000), (100000000, 0)))
     def test_empty_image(self, size: tuple[int, int]) -> None:
         Image.new("RGB", size)

--- a/Tests/test_imagefontpil.py
+++ b/Tests/test_imagefontpil.py
@@ -7,7 +7,7 @@ import pytest
 
 from PIL import Image, ImageDraw, ImageFont, _util, features
 
-from .helper import assert_image_equal_tofile, timeout_unless_slower_valgrind
+from .helper import assert_image_equal_tofile, timeout_unless_slower
 
 fonts = [ImageFont.load_default_imagefont()]
 if not features.check_module("freetype2"):
@@ -78,7 +78,7 @@ def test_decompression_bomb() -> None:
         font.getmask("A" * 1_000_000)
 
 
-@timeout_unless_slower_valgrind(4)
+@timeout_unless_slower(4)
 def test_oom() -> None:
     glyph = struct.pack(
         ">hhhhhhhhhh", 1, 0, -32767, -32767, 32767, 32767, -32767, -32767, 32767, 32767

--- a/Tests/test_imagemorph.py
+++ b/Tests/test_imagemorph.py
@@ -7,7 +7,7 @@ import pytest
 
 from PIL import Image, ImageMorph, _imagingmorph
 
-from .helper import assert_image_equal_tofile, hopper, timeout_unless_slower_valgrind
+from .helper import assert_image_equal_tofile, hopper, timeout_unless_slower
 
 
 def string_to_img(image_string: str) -> Image.Image:
@@ -266,7 +266,7 @@ def test_unknown_pattern() -> None:
 @pytest.mark.parametrize(
     "pattern", ("a pattern with a syntax error", "4:(" + "X" * 30000)
 )
-@timeout_unless_slower_valgrind(1)
+@timeout_unless_slower(1)
 def test_pattern_syntax_error(pattern: str) -> None:
     # Arrange
     lb = ImageMorph.LutBuilder(op_name="corner")


### PR DESCRIPTION
The latest commit added to https://github.com/python-pillow/Pillow/pull/9463 says
> The test_redos test has a 1-second timeout that fails under QEMU emulation where riscv64 regex operations are significantly slower than on native hardware.

and attempts to skip the entire test suite.

I think it would less extreme to only skip timeout-based tests. We already do this when running valgrind.